### PR TITLE
Add TLS cert section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ $ ./tunalog_linux_x64
 
 2. Double-click the downloaded `tunalog_windows_x64.exe` file to run.
 
+### Using a self-signed TLS certificate
+
+Adopted from [Gin 101: Enable TLS/SSL](https://medium.com/@pointgoal/gin-101-enable-tls-ssl-e84090aeb432)
+
+```bash
+$ go install -ldflags="-s -w" github.com/cloudflare/cfssl/cmd/cfssl@latest
+$ go install -ldflags="-s -w" github.com/cloudflare/cfssl/cmd/cfssljson@latest
+$ cd ~/tunalog
+$ mkdir cert
+$ cd cert
+$ cfssl print-defaults config > ca-config.json
+$ cfssl print-defaults csr > ca-csr.json
+# now edit `ca-csr.json` for your site-specific settings
+$ cfssl gencert -initca ca-csr.json | cfssljson -bare ca -
+# this creates: ca.pem, ca-key.pem, ca.csr
+$ cfssl gencert -config ca-config.json -ca ca.pem -ca-key ca-key.pem -profile www ca-csr.json | cfssljson -bare server
+# this creates: server.pem, server-key.pem, server.csr
+$ cd ..
+$ ./tunalog_YourOS_YourArch -p :8443 --tls-key cert/server-key.pem --tls-crt cert/server.pem
+```
+
 &nbsp;
 
 ## Help


### PR DESCRIPTION
This procedure allows you to locally run `tunalog` over `https`.

I need this because I am working on another patch that will add a `copy to clipboard` style button to code blocks.  Due to browser security, this functionality will only work over `https`.  Therefore, I am writing up this procedure.

I imagine that this will eventually be placed into a FAQ page once that has been established.
