### PR TITLE
fix: prevent HTML escaping in injected post content

### DIFF
--- a/system/themes/default/singular.html
+++ b/system/themes/default/singular.html
@@ -117,7 +117,7 @@
 
             <!-- content -->
             {{ if .IsUnlocked }}
-                {{ .Config.InjectedPostStart }}
+                {{ .Config.InjectedPostStart | html }}
 
                 {{ if eq .Config.AuthorBlock "start" }}
                     {{ template "author.html" . }}
@@ -139,7 +139,7 @@
                     {{ template "author.html" . }}
                 {{ end }}
 
-                {{ .Config.InjectedPostEnd }}
+                {{ .Config.InjectedPostEnd | html }}
             {{ else }}
                 <!-- locked -->
                 {{ if .Message }}


### PR DESCRIPTION
The InjectedPostStart and InjectedPostEnd template variables were being rendered without the 'html' filter, causing HTML content to be escaped and displayed as plain text instead of being properly rendered. This fix adds the missing HTML filter to ensure content such as embedded scripts and other HTML elements are properly rendered on post pages.